### PR TITLE
适配空 ip 地址，简化自动选择IP地址代码

### DIFF
--- a/optinos.go
+++ b/optinos.go
@@ -1,8 +1,10 @@
 package xxl
 
 import (
-	"github.com/go-basic/ipv4"
+	"strings"
 	"time"
+
+	"github.com/go-basic/ipv4"
 )
 
 type Options struct {
@@ -59,7 +61,9 @@ func AccessToken(token string) Option {
 // ExecutorIp 设置执行器IP
 func ExecutorIp(ip string) Option {
 	return func(o *Options) {
-		o.ExecutorIp = ip
+		if strings.TrimSpace(ip) != "" {
+			o.ExecutorIp = ip
+		}
 	}
 }
 


### PR DESCRIPTION
原方案中如果要通过配置文件适配，需要在外面判断是否是空 IP地址，此层判断封装内部更合适