### PR TITLE
执行器ip从配置文件中获取，开发环境需要指定ip，而生产环境(k8s)需要自动获取ip(给空)，会导致注册到xxl_job_admin中的…

### DIFF
--- a/optinos.go
+++ b/optinos.go
@@ -59,7 +59,9 @@ func AccessToken(token string) Option {
 // ExecutorIp 设置执行器IP
 func ExecutorIp(ip string) Option {
 	return func(o *Options) {
-		o.ExecutorIp = ip
+		if ip != "" {
+			o.ExecutorIp = ip
+		}
 	}
 }
 


### PR DESCRIPTION
…执行器ip为空，所以判断一下，传入的ip是空，就不要设置了，使用自动获取的ip