### PR TITLE
添加ExecutorHost参数支持，可以方便内网调试

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ func main() {
 	exec := xxl.NewExecutor(
 		xxl.ServerAddr("http://127.0.0.1/xxl-job-admin"),
 		xxl.AccessToken(""),            //请求令牌(默认为空)
+        xxl.ExecutorHost("http://test.com"), //提供一个可以访问的域名，如果设置了，会优先把这个访问回调地址注册到admin。在开发测试阶段可以用ngrok反代一个到本地的9999端口
 		xxl.ExecutorIp("127.0.0.1"),    //可自动获取
 		xxl.ExecutorPort("9999"),       //默认9999（非必填）
 		xxl.RegistryKey("golang-jobs"), //执行器名称

--- a/executor.go
+++ b/executor.go
@@ -76,7 +76,11 @@ func (e *executor) Init(opts ...Option) {
 	e.runList = &taskList{
 		data: make(map[string]*Task),
 	}
-	e.address = e.opts.ExecutorIp + ":" + e.opts.ExecutorPort
+	if e.opts.ExecutorHost != "" {
+		e.address = e.opts.ExecutorHost
+	} else {
+		e.address = e.opts.ExecutorIp + ":" + e.opts.ExecutorPort
+	}
 	go e.registry()
 }
 
@@ -105,7 +109,7 @@ func (e *executor) Run() (err error) {
 		Handler:      mux,
 	}
 	// 监听端口并提供服务
-	e.log.Info("Starting server at " + e.address)
+	e.log.Info("Starting server at " + e.opts.ExecutorIp + ":" + e.opts.ExecutorPort)
 	go server.ListenAndServe()
 	quit := make(chan os.Signal)
 	signal.Notify(quit, syscall.SIGKILL, syscall.SIGQUIT, syscall.SIGINT, syscall.SIGTERM)

--- a/optinos.go
+++ b/optinos.go
@@ -1,14 +1,16 @@
 package xxl
 
 import (
-	"github.com/go-basic/ipv4"
 	"time"
+
+	"github.com/go-basic/ipv4"
 )
 
 type Options struct {
 	ServerAddr   string        `json:"server_addr"`   //调度中心地址
 	AccessToken  string        `json:"access_token"`  //请求令牌
 	Timeout      time.Duration `json:"timeout"`       //接口超时时间
+	ExecutorHost string        `json:"executor_host"` //本地（执行器）访问域名，跨网支持，优先级高于ip+port
 	ExecutorIp   string        `json:"executor_ip"`   //本地(执行器)IP(可自行获取)
 	ExecutorPort string        `json:"executor_port"` //本地(执行器)端口
 	RegistryKey  string        `json:"registry_key"`  //执行器名称
@@ -81,5 +83,11 @@ func RegistryKey(registryKey string) Option {
 func SetLogger(l Logger) Option {
 	return func(o *Options) {
 		o.l = l
+	}
+}
+
+func ExecutorHost(host string) Option {
+	return func(o *Options) {
+		o.ExecutorHost = host
 	}
 }


### PR DESCRIPTION
添加ExecutorHost参数，服务端和开发测试不在一个网段的时候，提供host给admin回调executor的任务